### PR TITLE
Remove `id` from domain props

### DIFF
--- a/src/modules/chat/domain/Organization.ts
+++ b/src/modules/chat/domain/Organization.ts
@@ -1,9 +1,6 @@
-// Otional: 自分たちで考えたものなのであんまり重要ではない
 import { Entity } from "../../../shared/domain/Entity";
-import { UniqueID } from "../../../shared/domain/UniqueID";
 
 type OrganizationProps = {
-  id: UniqueID;
   name: string;
   createdAt?: Date;
 };

--- a/src/modules/chat/domain/ScheduledChatMessage.ts
+++ b/src/modules/chat/domain/ScheduledChatMessage.ts
@@ -3,7 +3,6 @@ import { UniqueID } from "../../../shared/domain/UniqueID";
 import { ScheduleStatus } from "./ScheduleStatus";
 
 type ScheduledChatMessageProps = {
-  id: UniqueID;
   body: string;
   userId: UniqueID;
   scheduleStatus: ScheduleStatus;

--- a/src/modules/users/domain/User.ts
+++ b/src/modules/users/domain/User.ts
@@ -1,8 +1,6 @@
 import { Entity } from "../../../shared/domain/Entity";
-import { UniqueID } from "../../../shared/domain/UniqueID";
 
 type UserProps = {
-  id: UniqueID;
   name: string;
   email: string;
   password: string;


### PR DESCRIPTION
`Entity._id`にuniqueIdはあるので，わざわざpropsに持つ必要は無く，無駄に作ることになってしまっている